### PR TITLE
对齐脚本那里可能存在的bug

### DIFF
--- a/Champollion/champ_res.py
+++ b/Champollion/champ_res.py
@@ -44,8 +44,8 @@ def align_sent(ch_file, en_file, res_file, write_ch, write_en):
                 wch.write('{}\n'.format(ch_sent))
                 wen.write('{}\n'.format(en_sent))
 
-                ch_sent,en_sent='',''
                 write_cnt+=1
+            ch_sent,en_sent='',''
     print(write_cnt)
 
 if __name__=='__main__':


### PR DESCRIPTION
嘿，您好，我发现在champollion得到对齐文件后，对齐omitted的句子并没有去除，一并写入了后一句。对比champollion里得到的输出文件是有区别的。具体可以看看champollion里eval路径下的例子。